### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,9 @@ jobs:
   draft_release:
     name: Release Drafter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Run release-drafter
         uses: release-drafter/release-drafter@v6.1.0


### PR DESCRIPTION
Potential fix for [https://github.com/BJReplay/oz-poll/security/code-scanning/1](https://github.com/BJReplay/oz-poll/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow or job to explicitly define the required permissions for the `GITHUB_TOKEN`. Since the workflow is drafting release notes, it likely only needs read access to repository contents and write access to pull requests. 

The fix involves:
1. Adding a `permissions` block at the job level (`draft_release`) to limit the permissions of the `GITHUB_TOKEN`.
2. Setting `contents: read` and `pull-requests: write` as the minimal permissions required for the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
